### PR TITLE
fix: declare node24 runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ outputs:
     description: "semver value based on the git describe data, similar to https://github.com/mdomke/git-semver"
 
 runs:
-  using: "node16"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
Every workflow consuming this action currently logs GitHub's Node deprecation annotation ("actions target Node.js 20/16 but are being forced to run on Node.js 24"). The action still declares `node16` in `action.yml` while runners have force-run it on newer Node for a while — so this is purely aligning the declaration with how it already executes, and it silences the warning in every consuming repo.

## Summary

- `runs.using`: `node16` → `node24`. No code change; the ncc bundle targets current `@actions/core` (v3) and has been executing on Node 24 runners already.

## Verification

- The action has been running on forced Node 24 in production workflows (e.g. contiamo/bg's Build and Publish today) with correct `shortSHA`/`semver` outputs — this PR changes only the declared runtime to match.